### PR TITLE
feat: modularize and lint docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*.egg-info/
+build/
 # These are some examples of commonly ignored file patterns.
 # You should customize this list as applicable to your project.
 # Learn more about .gitignore:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM python:3-alpine as main
 
 WORKDIR /app
 
@@ -9,5 +9,11 @@ COPY requirements.txt requirements.txt
 RUN pip3 install -r requirements.txt
 
 COPY officeplanner.py officeplanner.py
+
+FROM main as lint
+RUN pip3 install pylint
+RUN python -m pylint officeplanner.py
+
+FROM main as run
 
 CMD [ "python3", "officeplanner.py" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "officeplanner"
+version = "0.0.1"
+authors = [{ name = "Entur AS" }]
+description = "A small utility for indicating presence at the offices, via slack."
+readme = "README.md"
+requires-python = ">=3.10"
+classifiers = [
+  "Programming Language :: Python :: 3",
+  "License :: OSI Approved :: EUPL License",
+  "Operating System :: OS Independent",
+]
+
+[project.urls]
+"Homepage" = "https://github.com/entur/officeplanner"
+"Bug Tracker" = "https://github.com/entur/officeplanner/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "officeplanner"
-version = "0.0.1"
+version = "1.0.0"
 authors = [{ name = "Entur AS" }]
 description = "A small utility for indicating presence at the offices, via slack."
 readme = "README.md"


### PR DESCRIPTION
This will enable downstream users to:

```sh
pip3 install git+https://github.com/entur/officeplanner.git
python3 -m officeplanner
```
