### PR TITLE
feat: add k8s cronjob support

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -8,6 +8,7 @@ name: Create and publish a Docker image
 on:
   push:
     branches: ['main']
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/pr-lint.yaml
+++ b/.github/workflows/pr-lint.yaml
@@ -1,6 +1,8 @@
 name: Build docker image
 
-on: [pull_request]
+on:
+  - pull_request
+  - workflow_dispatch
 
 jobs:
   build-and-lint:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,12 @@
-FROM python:3-alpine as main
+FROM python:3-alpine
 
 WORKDIR /app
+RUN pip3 install --no-cache-dir slack_sdk pylint
 
 RUN addgroup -S appgroup && adduser -S appuser -G appgroup
 USER appuser
 
-COPY requirements.txt requirements.txt
-RUN pip3 install -r requirements.txt
-
 COPY officeplanner.py officeplanner.py
-
-RUN pip3 install pylint
 RUN python -m pylint officeplanner.py
 
-CMD [ "python3", "officeplanner.py" ]
+ENTRYPOINT [ "python3", "officeplanner.py" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,12 @@ version: '3.5'
 
 services:
   officeplanner:
-    image: ghcr.io/entur/officeplanner:main
+    #image: ghcr.io/entur/officeplanner:main
+    build: .
     # environment:
+      # MODE: single
+      # SLACK_CHANNEL: '#tmp-test-officeplanner'
       # SLACK_BOT_TOKEN: xoxb-xxx-xxx-xxx
-    volumes:
-      - ./test.txt:/app/channels.txt
+      # GREETING=Attention woker drones, prepare yourselves for the grand return to the hive next week! We expect nothing but peak productivity and unwavering loyalty upon your return.
+    # volumes:
+    #   - ./channels.txt:/app/channels.txt

--- a/officeplanner.py
+++ b/officeplanner.py
@@ -5,7 +5,11 @@ import time
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 
-GREETING = "When are you planning to be in-office next week?"
+MODE = os.environ.get('MODE', 'file')
+CHANNELS_FILE = os.environ.get('CHANNELS_FILE', 'channels.txt')
+SLACK_CHANNEL= os.environ.get('SLACK_CHANNEL', '#office-planner')
+GREETING = os.environ.get('GREETING', "When are you planning to be in-office next week?")
+
 OK = "ok"
 ERROR = "error"
 MSG = "message"
@@ -18,8 +22,11 @@ ASSERT_ERROR = "Expected error state to be true"
 
 client = WebClient(token=os.environ['SLACK_BOT_TOKEN'])
 
-with open('channels.txt', 'r', encoding='UTF-8') as file:
-    channels = [line.rstrip() for line in file]
+if MODE == 'file':
+    with open(CHANNELS_FILE, 'r', encoding='UTF-8') as file:
+        channels = [line.rstrip() for line in file]
+elif MODE == 'single':
+    channels = [SLACK_CHANNEL]
 
 for channel in channels:
     try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-slack_sdk


### PR DESCRIPTION
Add support for running OfficePlanner with single Slack channel target. Allows creating multiple Kubernetes Cronjobs with customized greeting and schedule for each team.

Defaults to `FILE` for backwards-compatibility.
